### PR TITLE
Backend: SCaLE 22x Prep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /wasgehtd
-/rrds/**
-/html/imgs/**
+/data/**

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ deps:
 
 clean:
 	rm wasgehtd
-	rm -rf html/imgs
+	rm -rf data/graphs/*
 
 mrproper: clean
-	rm -rfi rrds/*
+	rm -rfi data/*

--- a/README.md
+++ b/README.md
@@ -1,0 +1,125 @@
+# Was Geht
+
+## Overview
+
+**Was Geht** is a small Go application that pings a list of hosts at regular intervals, tracks their availability (UP or DOWN), and records the latency in a Round Robin Database (RRD). A lightweight web interface serves host status information and interactive graphs of the recorded latency.
+
+## Features
+
+- **Ping Monitoring**: Sends ICMP Echo Requests to check host availability.
+- **Latency Logging**: Uses RRD to store latency data over time.
+- **Graphs Generation**: Generates historical latency graphs (15 minutes, 4 hours, 8 hours, etc.) for each host.
+- **Simple Web Interface**: Serves an HTML/JS front-end to display host status and dynamically loaded graphs.
+- **REST API**: Exposes JSON data of all hosts and their status at `GET /api`.
+
+## Requirements
+
+
+### Using Nix (Recommended)
+
+If you have **Nix** installed, you can simply enter a development shell with all required dependencies using:
+
+```bash
+nix-shell
+```
+
+This loads the environment specified in `shell.nix`:
+
+- Go (for building),
+- gnumake (for Makefile),
+- rrdtool (for handling RRD databases),
+- unixtools.ping (ping utility).
+
+Once inside the shell, you can run the usual make commands
+
+### Without Nix ###
+
+Ensure the following are installed:
+
+- **Go** (1.23+ recommended)
+- **rrdtool** and **iputils ping** must be installed and available on the system path.
+- Basic Unix tools for building and running (`make`, etc.).
+
+## Quick Start
+
+1. **Clone** the repository:
+    ```bash
+    git clone https://github.com/kylerisse/wasgeht.git
+    cd wasgeht
+    ```
+
+2. **Install dependencies**:
+    ```bash
+    make deps
+    ```
+
+3. **Build** the binary:
+    ```bash
+    make build
+    ```
+    This will compile the Go code and produce a `wasgehtd` binary in the project root.
+
+4. **Prepare data directories**:
+
+   By default, Was Geht expects two subdirectories under `./data`:
+   - `rrds` for storing RRD files
+   - `graphs` for storing generated graph images
+
+   These directories will be created automatically if they do not exist, but make sure that `./data` itself exists.
+
+5. **Configure hosts**:
+
+   Update or create your own JSON file listing your hosts (see `sample-hosts.json` for reference).
+
+6. **Run** the application:
+    ```bash
+    ./wasgehtd --host-file=sample-hosts.json --data-dir=./data --port=1982 --log-level=info
+    ```
+
+7. **Access the web interface**:
+
+   Open your browser to [http://localhost:1982](http://localhost:1982). The main table shows all hosts and their current status (UP or DOWN). Hover over the status to see a latency graph.
+
+## Configuration
+
+- **Host File** (`--host-file`): Path to the JSON file specifying host definitions.
+- **Data Directory** (`--data-dir`): Root directory that contains `rrds/` and `graphs/`.
+- **Port** (`--port`): Port on which the API and front-end are served.
+- **Logging Level** (`--log-level`): Set the verbosity of logs (e.g., `debug`, `info`, `warn`, `error`, `fatal`, `panic`).
+
+## Makefile Targets
+
+- **build**: Compiles the Go code and produces `wasgehtd`.
+- **deps**: Verifies module dependencies and updates `go.mod` and `go.sum`.
+- **clean**: Removes the `wasgehtd` binary and any generated graphs.
+- **mrproper**: Removes all data including RRD files and generated graphs.
+
+## Contributing
+
+1. Fork the repository.
+2. Create a new feature or bugfix branch.
+3. Send a pull request (PR).
+
+## License
+
+MIT License
+
+Copyright (c) 2025 Kyle Risse
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cmd/wasgehtd/main.go
+++ b/cmd/wasgehtd/main.go
@@ -16,7 +16,7 @@ func main() {
 	logLevel := flag.String("log-level", "info", "Set the logging level (debug, info, warn, error, fatal, panic)")
 	hostFile := flag.String("host-file", "sample-hosts.json", "Path to the host configuration file")
 	dataDir := flag.String("data-dir", "./data", "Path to the data directory containing 'rrds' and 'graphs' folders")
-
+	listenPort := flag.String("port", "1982", "Port to listen on")
 	flag.Parse()
 
 	// Configure logrus to log to stdout with appropriate log level
@@ -51,7 +51,7 @@ func main() {
 	}
 
 	// Load the server with hosts and configuration
-	srv, err := server.NewServer(*hostFile, rrdDir, graphDir, logger)
+	srv, err := server.NewServer(*hostFile, rrdDir, graphDir, *listenPort, logger)
 	if err != nil {
 		logger.Fatalf("Failed to start server: %v", err)
 	}

--- a/cmd/wasgehtd/main.go
+++ b/cmd/wasgehtd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"os/signal"
 	"sync"
@@ -14,8 +15,7 @@ import (
 func main() {
 	logLevel := flag.String("log-level", "info", "Set the logging level (debug, info, warn, error, fatal, panic)")
 	hostFile := flag.String("host-file", "sample-hosts.json", "Path to the host configuration file")
-	rrdDir := flag.String("rrd-dir", "./rrds", "Path to the RRD files directory")
-	htmlDir := flag.String("html-dir", "./html", "Path to the HTML files directory")
+	dataDir := flag.String("data-dir", "./data", "Path to the data directory containing 'rrds' and 'graphs' folders")
 
 	flag.Parse()
 
@@ -34,8 +34,24 @@ func main() {
 
 	var wg sync.WaitGroup
 
+	rrdDir := fmt.Sprintf("%s/rrds", *dataDir)
+	graphDir := fmt.Sprintf("%s/graphs", *dataDir)
+
+	// ensure the root data directory exists
+	if _, err := os.Stat(*dataDir); os.IsNotExist(err) {
+		logger.Fatalf("data directory %v does not exist, %v", dataDir, err)
+	}
+
+	// Create the rrds and graphs directories if they don't exist
+	if err := os.MkdirAll(rrdDir, 0755); err != nil {
+		logger.Fatalf("Failed to create rrds directory: %v", err)
+	}
+	if err := os.MkdirAll(graphDir, 0755); err != nil {
+		logger.Fatalf("Failed to create graphs directory: %v", err)
+	}
+
 	// Load the server with hosts and configuration
-	srv, err := server.NewServer(*hostFile, *rrdDir, *htmlDir, logger)
+	srv, err := server.NewServer(*hostFile, rrdDir, graphDir, logger)
 	if err != nil {
 		logger.Fatalf("Failed to start server: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kylerisse/wasgeht
 
-go 1.23.3
+go 1.23
 
 require github.com/sirupsen/logrus v1.9.3
 

--- a/pkg/rrd/graph.go
+++ b/pkg/rrd/graph.go
@@ -62,7 +62,7 @@ func newGraph(host string, htmlDir string, rrdPath string, timeLength string, co
 		metric:                metric,
 		unit:                  "ms",
 		consolidationFunction: consolidationFunction,
-		color:                 RED,
+		color:                 GREEN,
 		comment:               comment,
 		logger:                logger,
 	}
@@ -110,7 +110,7 @@ func (g *graph) draw() error {
 	cdefs = append(cdefs, cdef)
 
 	lines := []string{
-		fmt.Sprintf("LINE1:%s_%s#%s:%s", g.metric, g.unit, g.color, g.label),
+		fmt.Sprintf("AREA:%s_%s#%s:%s", g.metric, g.unit, g.color, g.label),
 	}
 
 	gprints := []string{}

--- a/pkg/rrd/graph.go
+++ b/pkg/rrd/graph.go
@@ -28,7 +28,7 @@ type graph struct {
 //
 // Parameters:
 //   - host: The name of the host.
-//   - htmlDir: The path to the HTML directory.
+//   - graphDir: The path to the graphs directory.
 //   - rrdPath: The path to the RRD file.
 //   - timeLength: The time range for the graph (e.g., "4h").
 //   - consolidationFunction: The RRD consolidation function ("AVERAGE", "MAX", etc.).
@@ -38,10 +38,10 @@ type graph struct {
 // Returns:
 //   - *Graph: A pointer to the newly created Graph struct.
 //   - error: An error if something went wrong during the initialization.
-func newGraph(host string, htmlDir string, rrdPath string, timeLength string, consolidationFunction string, metric string, logger *logrus.Logger) (*graph, error) {
+func newGraph(host string, graphDir string, rrdPath string, timeLength string, consolidationFunction string, metric string, logger *logrus.Logger) (*graph, error) {
 
 	// Define directory and file paths
-	dirPath := fmt.Sprintf("%s/imgs/%s", htmlDir, host)
+	dirPath := fmt.Sprintf("%s/imgs/%s", graphDir, host)
 	filePath := fmt.Sprintf("%s/%s_%s_%s.png", dirPath, host, metric, timeLength)
 
 	// Ensure the directory exists

--- a/pkg/rrd/helpers.go
+++ b/pkg/rrd/helpers.go
@@ -5,6 +5,8 @@ const GREEN = "00FF00"
 
 func expandTimeLength(timeLength string) string {
 	switch timeLength {
+	case "15m":
+		return "fifteen minutes"
 	case "1h":
 		return "one hour"
 	case "4h":

--- a/pkg/rrd/helpers.go
+++ b/pkg/rrd/helpers.go
@@ -1,6 +1,7 @@
 package rrd
 
 const RED = "FF0000"
+const GREEN = "00FF00"
 
 func expandTimeLength(timeLength string) string {
 	switch timeLength {

--- a/pkg/rrd/rrd.go
+++ b/pkg/rrd/rrd.go
@@ -198,8 +198,7 @@ func (r *RRD) SafeUpdate(timestamp time.Time, values []float64) error {
 // This method adds multiple graphs (e.g., hourly, daily, weekly, etc.) to the RRD.
 func (r *RRD) initGraphs() {
 	// Define the list of time lengths and consolidation functions for each graph.
-	timeLengthsMax := []string{"1h", "4h", "8h"}                 // Only use "MAX" for these time lengths.
-	timeLengthsAverage := []string{"1d", "4d", "1w", "1m", "1y"} // Only use "AVERAGE" for these time lengths.
+	timeLengthsMax := []string{"15m", "4h", "8h", "1d", "4d", "1w"} // Only use "MAX" for these time lengths.
 
 	// Loop over each time length to create graphs with MAX consolidation function.
 	for _, timeLength := range timeLengthsMax {
@@ -210,17 +209,6 @@ func (r *RRD) initGraphs() {
 		}
 		r.graphs = append(r.graphs, graph)
 		r.logger.Debugf("Added MAX graph for host %s with time length %s.", r.host.Name, timeLength)
-	}
-
-	// Loop over each time length to create graphs with AVERAGE consolidation function.
-	for _, timeLength := range timeLengthsAverage {
-		graph, err := newGraph(r.host.Name, r.htmlDir, r.file.Name(), timeLength, "AVERAGE", r.metric, r.logger)
-		if err != nil {
-			r.logger.Errorf("Failed to create AVERAGE graph for host %s with time length %s: %v", r.host.Name, timeLength, err)
-			continue
-		}
-		r.graphs = append(r.graphs, graph)
-		r.logger.Debugf("Added AVERAGE graph for host %s with time length %s.", r.host.Name, timeLength)
 	}
 
 	r.logger.Debugf("Total graphs initialized for host %s: %d", r.host.Name, len(r.graphs))

--- a/pkg/rrd/rrd.go
+++ b/pkg/rrd/rrd.go
@@ -16,13 +16,13 @@ import (
 // RRD represents an RRD file, including metadata and synchronization tools.
 // It contains the file pointer, a mutex for thread safety, a list of data sources, and archive definitions.
 type RRD struct {
-	host    *host.Host
-	metric  string
-	file    *os.File      // Pointer to the actual RRD file
-	mutex   *sync.RWMutex // Wrap file access
-	graphs  []*graph
-	logger  *logrus.Logger
-	htmlDir string
+	host     *host.Host
+	metric   string
+	file     *os.File      // Pointer to the actual RRD file
+	mutex    *sync.RWMutex // Wrap file access
+	graphs   []*graph
+	logger   *logrus.Logger
+	graphDir string
 }
 
 // NewRRD creates and initializes a new RRD struct for the specified host.
@@ -31,17 +31,17 @@ type RRD struct {
 // Parameters:
 //   - host: The name of the host for which the RRD file will be created.
 //   - rrdDir: The directory where the RRD file should be stored.
-//   - htmlDir: The directory where the HTML files (graphs) should be stored.
+//   - graphDir: The directory where the graphs should be stored.
 //   - metric: The metric name.
 //   - logger: The logger instance.
 //
 // Returns:
 //   - *RRD: A pointer to the newly created RRD struct.
 //   - error: An error if something went wrong during the initialization or creation of the RRD file.
-func NewRRD(host *host.Host, rrdDir string, htmlDir string, metric string, logger *logrus.Logger) (*RRD, error) {
-	// verify root Dir exists
+func NewRRD(host *host.Host, rrdDir string, graphDir string, metric string, logger *logrus.Logger) (*RRD, error) {
+	// verify rrdDir exists
 	if _, err := os.Stat(rrdDir); os.IsNotExist(err) {
-		return nil, fmt.Errorf("root directory %s does not exist", rrdDir)
+		return nil, fmt.Errorf("directory %s does not exist", rrdDir)
 	}
 
 	// Construct the RRD file path including the metric name
@@ -72,13 +72,13 @@ func NewRRD(host *host.Host, rrdDir string, htmlDir string, metric string, logge
 
 	// Initialize the RRD struct
 	rrd := &RRD{
-		host:    host,
-		metric:  metric,
-		file:    file,
-		mutex:   &sync.RWMutex{},
-		graphs:  []*graph{},
-		logger:  logger,
-		htmlDir: htmlDir,
+		host:     host,
+		metric:   metric,
+		file:     file,
+		mutex:    &sync.RWMutex{},
+		graphs:   []*graph{},
+		logger:   logger,
+		graphDir: graphDir,
 	}
 
 	rrd.initGraphs()
@@ -202,7 +202,7 @@ func (r *RRD) initGraphs() {
 
 	// Loop over each time length to create graphs with MAX consolidation function.
 	for _, timeLength := range timeLengthsMax {
-		graph, err := newGraph(r.host.Name, r.htmlDir, r.file.Name(), timeLength, "MAX", r.metric, r.logger)
+		graph, err := newGraph(r.host.Name, r.graphDir, r.file.Name(), timeLength, "MAX", r.metric, r.logger)
 		if err != nil {
 			r.logger.Errorf("Failed to create MAX graph for host %s with time length %s: %v", r.host.Name, timeLength, err)
 			continue

--- a/pkg/rrd/rrd.go
+++ b/pkg/rrd/rrd.go
@@ -53,14 +53,7 @@ func NewRRD(host *host.Host, rrdDir string, htmlDir string, metric string, logge
 		cmd := exec.Command("rrdtool", "create", rrdPath,
 			"--step", "60",
 			fmt.Sprintf("DS:%s:GAUGE:120:0:U", metric),
-			"RRA:MAX:0.5:1:60",         // 1-minute max for 1 hour (60 data points)
-			"RRA:MAX:0.5:1:240",        // 1-minute max for 4 hour (60 data points)
-			"RRA:MAX:0.5:1:480",        // 1-minute max for 8 hours (480 data points)
-			"RRA:AVERAGE:0.5:1:1440",   // 1-minute average for 1 day (1440 data points)
-			"RRA:AVERAGE:0.5:1:5760",   // 1-minute average for 4 days (5760 data points)
-			"RRA:AVERAGE:0.5:1:10080",  // 1-minute average for 1 week (10080 data points)
-			"RRA:AVERAGE:0.5:60:720",   // 1-hour average for 1 month (720 data points, 30 days)
-			"RRA:AVERAGE:0.5:1440:365", // 1-day average for 1 year (365 data points)
+			"RRA:MAX:0.5:1:10080", // 1-minute max for 1 week (10080 data points)
 		)
 
 		// Run the command

--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -39,8 +39,8 @@ func (s *Server) startAPI() {
 	http.Handle("/", noCacheMiddleware((http.StripPrefix("/", htmlFS))))
 
 	go func() {
-		s.logger.Info("Starting API server on port 1982...")
-		if err := http.ListenAndServe(":1982", nil); err != nil {
+		s.logger.Infof("Starting API server on port %v...", s.listenPort)
+		if err := http.ListenAndServe(":"+s.listenPort, nil); err != nil {
 			s.logger.Fatalf("Failed to start API server: %v", err)
 		}
 	}()

--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -37,7 +37,7 @@ func (s *Server) startAPI() {
 
 	// Serve static content
 	htmlFS := http.FileServer(http.FS(content))
-	http.Handle("/", (http.StripPrefix("/", htmlFS)))
+	http.Handle("/", noCacheMiddleware((http.StripPrefix("/", htmlFS))))
 
 	go func() {
 		s.logger.Info("Starting API server on port 1982...")

--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"io/fs"
 	"net/http"
-	"path/filepath"
 	"time"
 )
 
@@ -31,9 +30,9 @@ func (s *Server) startAPI() {
 		s.logger.Fatalf("Failed to create sub filesystem: %v", err)
 	}
 
-	// Serve generated images
-	imgFS := http.FileServer(http.Dir(filepath.Join(s.htmlDir, "imgs")))
-	http.Handle("/imgs/", noCacheMiddleware(http.StripPrefix("/imgs", imgFS)))
+	// Serve generated graphs from the graphDir
+	imgFS := http.FileServer(http.Dir(s.graphDir))
+	http.Handle("/imgs/", noCacheMiddleware(imgFS))
 
 	// Serve static content
 	htmlFS := http.FileServer(http.FS(content))

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -12,27 +12,27 @@ import (
 
 // Server represents the ping server
 type Server struct {
-	hosts   map[string]*host.Host
-	done    chan struct{}
-	wg      sync.WaitGroup
-	logger  *logrus.Logger
-	rrdDir  string
-	htmlDir string
+	hosts    map[string]*host.Host
+	done     chan struct{}
+	wg       sync.WaitGroup
+	logger   *logrus.Logger
+	rrdDir   string
+	graphDir string
 }
 
 // NewServer initializes a new server with the given host file
-func NewServer(hostFile string, rrdDir string, htmlDir string, logger *logrus.Logger) (*Server, error) {
+func NewServer(hostFile string, rrdDir string, graphDir string, logger *logrus.Logger) (*Server, error) {
 	hosts, err := loadHosts(hostFile)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Server{
-		hosts:   hosts,
-		done:    make(chan struct{}),
-		logger:  logger,
-		rrdDir:  rrdDir,
-		htmlDir: htmlDir,
+		hosts:    hosts,
+		done:     make(chan struct{}),
+		logger:   logger,
+		rrdDir:   rrdDir,
+		graphDir: graphDir,
 	}, nil
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -12,27 +12,29 @@ import (
 
 // Server represents the ping server
 type Server struct {
-	hosts    map[string]*host.Host
-	done     chan struct{}
-	wg       sync.WaitGroup
-	logger   *logrus.Logger
-	rrdDir   string
-	graphDir string
+	hosts      map[string]*host.Host
+	done       chan struct{}
+	wg         sync.WaitGroup
+	logger     *logrus.Logger
+	rrdDir     string
+	graphDir   string
+	listenPort string
 }
 
 // NewServer initializes a new server with the given host file
-func NewServer(hostFile string, rrdDir string, graphDir string, logger *logrus.Logger) (*Server, error) {
+func NewServer(hostFile string, rrdDir string, graphDir string, listenPort string, logger *logrus.Logger) (*Server, error) {
 	hosts, err := loadHosts(hostFile)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Server{
-		hosts:    hosts,
-		done:     make(chan struct{}),
-		logger:   logger,
-		rrdDir:   rrdDir,
-		graphDir: graphDir,
+		hosts:      hosts,
+		done:       make(chan struct{}),
+		logger:     logger,
+		rrdDir:     rrdDir,
+		graphDir:   graphDir,
+		listenPort: listenPort,
 	}, nil
 }
 

--- a/pkg/server/static/scripts.js
+++ b/pkg/server/static/scripts.js
@@ -65,7 +65,7 @@ function updateTable(data) {
 
         const img = document.createElement("img");
         // Append a timestamp to prevent caching
-        img.src = `/imgs/${host}/${host}_latency_1h.png?${new Date().getTime()}`;
+        img.src = `/imgs/${host}/${host}_latency_15m.png?${new Date().getTime()}`;
         img.alt = `Latency graph for ${host}`;
         img.width = 600; // Adjust dimensions as needed
         img.height = 200;
@@ -83,7 +83,7 @@ function updateTable(data) {
         // Preload image when updating
         function updateImage() {
             const timestamp = new Date().getTime();
-            const newSrc = `/imgs/${host}/${host}_latency_1h.png?${timestamp}`;
+            const newSrc = `/imgs/${host}/${host}_latency_15m.png?${timestamp}`;
             const preloadImg = new Image();
             preloadImg.src = newSrc;
             preloadImg.onload = () => {

--- a/pkg/server/worker.go
+++ b/pkg/server/worker.go
@@ -13,7 +13,7 @@ func (s *Server) worker(name string, h *host.Host) {
 	defer s.wg.Done()
 
 	// Initialize RRD file for the host
-	rrdFile, err := rrd.NewRRD(h, s.rrdDir, s.htmlDir, "latency", s.logger)
+	rrdFile, err := rrd.NewRRD(h, s.rrdDir, s.graphDir, "latency", s.logger)
 	if err != nil {
 		s.logger.Errorf("Worker for host %s: Failed to initialize RRD (%v)", name, err)
 		return

--- a/sample-hosts.json
+++ b/sample-hosts.json
@@ -1,17 +1,7 @@
 {
   "router": {},
-  "ap1": {
-    "radios": [
-      "phy0-ap0",
-      "phy1-ap0"
-    ]
-  },
-  "ap2": {
-    "radios": [
-      "phy0-ap0",
-      "phy1-ap0"
-    ]
-  },
+  "ap1": {},
+  "ap2": {},
   "qube": {},
   "pi3": {},
   "pi4": {},

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,9 @@
+{ pkgs ? import <nixpkgs> { } }:
+pkgs.mkShell {
+  nativeBuildInputs = with pkgs; [
+    go
+    gnumake
+    rrdtool
+    unixtools.ping
+  ];
+}


### PR DESCRIPTION
Home stretch for SCaLE. Mostly backend changes so far with the overall goals:

**making it easier to package in Nix** (or operate in general)
- Added a flag to specify the port
- Consolidated the 2 data directory flags into 1
- Added a `README`
- Added a `shell.nix`

**optimizing it specifically for SCaLE**
- Reduced graphs to 1 week max
- Added 15 minute graphs
- Reworked startup and worker behavior to support hundreds of hosts and run as a polite neighbor on shared services server

TODO:
- optimize the dashboard to look good with hundreds of hosts