### PR TITLE
Adds prometheus endpoint

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1741010256,
+        "narHash": "sha256-WZNlK/KX7Sni0RyqLSqLPbK8k08Kq7H7RijPJbq9KHM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "ba487dbc9d04e0634c64e3b1f0d25839a0a68246",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -13,9 +13,10 @@
     {
       devShells."x86_64-linux".default = pkgs.mkShell {
         buildInputs = with pkgs; [
+          gnumake
           go
           gopls
-          gnumake
+          prometheus
           rrdtool
           unixtools.ping
         ];

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,24 @@
+{
+  description = "A very basic flake";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      pkgs = nixpkgs.legacyPackages.x86_64-linux.pkgs;
+    in
+    {
+      devShells."x86_64-linux".default = pkgs.mkShell {
+        buildInputs = with pkgs; [
+          go
+          gopls
+          gnumake
+          rrdtool
+          unixtools.ping
+        ];
+      };
+    };
+}

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,6 @@
+global:
+  scrape_interval: 15s
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:1982']

--- a/sample-hosts.json
+++ b/sample-hosts.json
@@ -16,5 +16,11 @@
   "fake4": {},
   "onedotone": {
     "address": "1.1.1.1"
+  },
+  "localhostv4": {
+    "address": "127.0.0.1"
+  },
+  "localhostv6": {
+    "address": "::1"
   }
 }


### PR DESCRIPTION
# This PR
Adds a prometheus api endpoint which can be scraped by prometheus

# Testing
Locally running `prometheus` while wasgeht is running, I can then query metrics via the web interface
![screenshot_2025-03-04-180905](https://github.com/user-attachments/assets/5f054c58-ec84-4669-bfe7-8faee6935c52)
